### PR TITLE
cache extended mappings and keep beanmapper thin

### DIFF
--- a/modules/beanmapper/build.gradle
+++ b/modules/beanmapper/build.gradle
@@ -4,7 +4,6 @@ dependencies {
 	compile group: 'org.springframework', name: 'spring-jdbc', version: springVersion
 	compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.2.1'
 	compile group: 'javax.persistence', name: 'persistence-api', version: '1.0.2'
-	compile group: 'com.google.guava', name: 'guava', version: guavaVersion
 }
 
 task testJar(type: Jar, dependsOn: testClasses){

--- a/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/BeanMapper.java
+++ b/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/BeanMapper.java
@@ -30,7 +30,6 @@ import org.springframework.jdbc.core.RowMapper;
 public class BeanMapper<B> implements RowMapper<B> {
 
     private BeanMapping<B> mapping;
-    private ExtendedBeanMapping<B> extendedMapping;
 
     private ResultSetReader resultSetReader;
 
@@ -40,16 +39,9 @@ public class BeanMapper<B> implements RowMapper<B> {
     }
 
     public BeanMapping<B> mapping() {
-        return extendedMapping != null ? extendedMapping : mapping;
+        return mapping;
     }
 
-    public void add(String property, String columnName) {
-        if (extendedMapping == null) {
-            extendedMapping = new ExtendedBeanMapping<>(mapping);
-        }
-        extendedMapping.addExtendedProperty(property, columnName);
-    }
-    
     @Override
     public B mapRow(ResultSet rs, int rowNum) throws SQLException {
         B o = mapping().instance();

--- a/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/BeanMapping.java
+++ b/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/BeanMapping.java
@@ -17,8 +17,6 @@ package com.nortal.petit.beanmapper;
 
 import java.util.Map;
 
-import com.google.common.base.Function;
-
 /**
  * A mapping of a bean as a collection of properties.
  * 
@@ -26,9 +24,9 @@ import com.google.common.base.Function;
  * 
  */
 public interface BeanMapping<B> {
-    
+
     public static final String USE_ADDITIONAL_CONFIGURATION_KEY = "com.nortal.persistence.useAdditionalConfiguration";
-    
+
     /**
      * Creates a new bean instance.
      */
@@ -49,8 +47,6 @@ public interface BeanMapping<B> {
      * property exists.
      */
     Property<B, Object> id();
-    
+
     Class<B> type();
-    
-    Function<String, String> getPropertyNameMapper(final boolean includeReadOnly);
 }

--- a/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/DelegateBeanMapping.java
+++ b/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/DelegateBeanMapping.java
@@ -15,29 +15,41 @@
  */
 package com.nortal.petit.beanmapper;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A beanmapping restricted to a set of properties.
- * 
  * @author Aleksei Lissitsin
- * 
  */
-public class RestrictedBeanMapping<B> extends DelegateBeanMapping<B> {
+public class DelegateBeanMapping<B> implements BeanMapping<B> {
 
-    private Map<String, Property<B, Object>> propMap = new HashMap<String, Property<B, Object>>();
+    protected BeanMapping<B> beanMapping;
 
-    public RestrictedBeanMapping(BeanMapping<B> beanMapping, String... props) {
-        super(beanMapping);
-        Map<String, Property<B, Object>> origMap = beanMapping.props();
-        for (String prop : props) {
-            propMap.put(prop, origMap.get(prop));
-        }
+    public DelegateBeanMapping(BeanMapping<B> beanMapping) {
+        this.beanMapping = beanMapping;
+    }
+
+    @Override
+    public B instance() {
+        return beanMapping.instance();
+    }
+
+    @Override
+    public String table() {
+        return beanMapping.table();
     }
 
     @Override
     public Map<String, Property<B, Object>> props() {
-        return propMap;
+        return beanMapping.props();
+    }
+
+    @Override
+    public Property<B, Object> id() {
+        return beanMapping.id();
+    }
+
+    @Override
+    public Class<B> type() {
+        return beanMapping.type();
     }
 }

--- a/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/ExtendedBeanMapping.java
+++ b/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/ExtendedBeanMapping.java
@@ -18,78 +18,32 @@ package com.nortal.petit.beanmapper;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.springframework.util.Assert;
-
-import com.google.common.base.Function;
-
 /**
- * Extended BeanMapping. Useful when adding custom fields (for example fields with Transient annotation)
- * to the default mapping.
+ * Extended BeanMapping. Useful when adding custom fields (for example fields
+ * with Transient annotation) to the default mapping.
  * 
  * @author Alrik Peets
  *
  * @param <B>
  */
-public class ExtendedBeanMapping<B> implements BeanMapping<B> {
+public class ExtendedBeanMapping<B> extends DelegateBeanMapping<B> {
 
-    private BeanMapping<B> beanMapping;
     private Map<String, Property<B, Object>> extendedProps = new LinkedHashMap<String, Property<B, Object>>();
-    
-    public ExtendedBeanMapping(BeanMapping<B> beanMapping) {
-        this.beanMapping = beanMapping;
-    }
-    
-    @Override
-    public B instance() {
-        return beanMapping.instance();
-    }
 
-    @Override
-    public String table() {
-        return beanMapping.table();
+    public ExtendedBeanMapping(BeanMapping<B> beanMapping,
+            Map<String, Property<B, Object>> extProps) {
+        super(beanMapping);
+        this.extendedProps = extProps;
     }
 
     @Override
     public Map<String, Property<B, Object>> props() {
-        Map<String, Property<B, Object>> props = new LinkedHashMap<String, Property<B, Object>>(beanMapping.props());
+        Map<String, Property<B, Object>> props = new LinkedHashMap<String, Property<B, Object>>(
+                beanMapping.props());
         for (String key : extendedProps.keySet()) {
             Property<B, Object> property = extendedProps.get(key);
             props.put(key, property);
         }
         return props;
-    }
-
-    @Override
-    public Property<B, Object> id() {
-        return beanMapping.id();
-    }
-
-    public void addExtendedProperty(String property, String columnName) {
-        BeanMappingUtils.initExtendedProperty(extendedProps, property, type(), columnName);
-    }
-    
-    @Override
-    public Function<String, String> getPropertyNameMapper(final boolean includeReadOnly) {
-        return new Function<String, String>() {
-            public String apply(String name) {
-                return getColumn(name, includeReadOnly);
-            }
-        };
-    }
-
-    private String getColumn(String name, boolean includeReadOnly) {
-        Property<B, Object> p = props().get(name);
-        if (p == null) {
-            Assert.notNull(p, "No property " + name + " found!");
-        }
-        if (includeReadOnly || !p.readOnly()) {
-            return p.column();
-        }
-        return null;
-    }
-
-    @Override
-    public Class<B> type() {
-        return beanMapping.type();
     }
 }

--- a/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/SimpleBeanMapping.java
+++ b/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/SimpleBeanMapping.java
@@ -17,10 +17,6 @@ package com.nortal.petit.beanmapper;
 
 import java.util.Map;
 
-import org.springframework.util.Assert;
-
-import com.google.common.base.Function;
-
 /**
  * A simple implementation of a BeanMapping.
  * 
@@ -68,26 +64,6 @@ public class SimpleBeanMapping<B> implements BeanMapping<B> {
     @Override
     public String toString() {
         return type.getSimpleName();
-    }
-
-    @Override
-    public Function<String, String> getPropertyNameMapper(final boolean includeReadOnly) {
-        return new Function<String, String>() {
-            public String apply(String name) {
-                return getColumn(name, includeReadOnly);
-            }
-        };
-    }
-    
-    private String getColumn(String name, boolean includeReadOnly) {
-        Property<B, Object> p = props().get(name);
-        if (p == null) {
-            Assert.notNull(p, "No property " + name + " found!");
-        }
-        if (includeReadOnly || !p.readOnly()) {
-            return p.column();
-        }
-        return null;
     }
 
     @Override

--- a/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/ext/ExtendedBeanMappingCache.java
+++ b/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/ext/ExtendedBeanMappingCache.java
@@ -1,0 +1,63 @@
+/**
+ *   Copyright 2014 Nortal AS
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.nortal.petit.beanmapper.ext;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import com.nortal.petit.beanmapper.BeanMapping;
+
+/**
+ * @author Aleksei Lissitsin
+ */
+class ExtendedBeanMappingCache {
+    private static ExtendedBeanMappingCache instance = new ExtendedBeanMappingCache();
+
+    private Map<String, BeanMapping<?>> map = new WeakHashMap<String, BeanMapping<?>>();
+    private boolean enabled = true;
+
+    @SuppressWarnings("unchecked")
+    protected <B> BeanMapping<B> get(Class<B> clazz, String... extendedProps) {
+        if (enabled) {
+            return (BeanMapping<B>) map.get(serialize(clazz, extendedProps));
+        }
+        return null;
+    }
+
+    protected <B> void put(Class<B> clazz, BeanMapping<B> mapping,
+            String... extendedProps) {
+        if (enabled) {
+            map.put(serialize(clazz, extendedProps), mapping);
+        }
+    }
+
+    protected void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    protected static ExtendedBeanMappingCache getInstance() {
+        return instance;
+    }
+
+    private static <B> String serialize(Class<B> clazz, String... extendedProps) {
+        StringBuilder sb = new StringBuilder(clazz.getCanonicalName());
+        for (String s : extendedProps) {
+            sb.append(";");
+            sb.append(s);
+        }
+        return sb.toString();
+    }
+}

--- a/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/ext/ExtendedBeanMappingFactory.java
+++ b/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/ext/ExtendedBeanMappingFactory.java
@@ -1,0 +1,27 @@
+/**
+ *   Copyright 2014 Nortal AS
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.nortal.petit.beanmapper.ext;
+
+import com.nortal.petit.beanmapper.BeanMapping;
+
+/**
+ * 
+ * @author Aleksei Lissitsin
+ *
+ */
+public interface ExtendedBeanMappingFactory {
+    <B> BeanMapping<B> create(Class<B> type, String... extendedProps);
+}

--- a/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/ext/ExtendedBeanMappingFactoryImpl.java
+++ b/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/ext/ExtendedBeanMappingFactoryImpl.java
@@ -1,0 +1,54 @@
+/**
+ *   Copyright 2014 Nortal AS
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.nortal.petit.beanmapper.ext;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.nortal.petit.beanmapper.BeanMapping;
+import com.nortal.petit.beanmapper.BeanMappingUtils;
+import com.nortal.petit.beanmapper.BeanMappings;
+import com.nortal.petit.beanmapper.ExtendedBeanMapping;
+import com.nortal.petit.beanmapper.Property;
+
+/**
+ * @author Aleksei Lissitsin
+ */
+public class ExtendedBeanMappingFactoryImpl implements
+        ExtendedBeanMappingFactory {
+
+    @Override
+    public <B> BeanMapping<B> create(Class<B> type, String... extendedProps) {
+        BeanMapping<B> beanMapping = BeanMappings.get(type);
+        Map<String, String> args = argsToMap(extendedProps);
+        Map<String, Property<B, Object>> extProps = new LinkedHashMap<String, Property<B, Object>>();
+        for (String prop : args.keySet()) {
+            BeanMappingUtils.initExtendedProperty(extProps, prop,
+                    beanMapping.type(), args.get(prop));
+        }
+
+        return new ExtendedBeanMapping<B>(beanMapping, extProps);
+    }
+
+    private static Map<String, String> argsToMap(String... extendedProps) {
+        Map<String, String> map = new LinkedHashMap<String, String>();
+        for (int i = 0; i < extendedProps.length; i+=2) {
+            map.put(extendedProps[i], extendedProps[i + 1]);
+        }
+        return map;
+    }
+
+}

--- a/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/ext/ExtendedBeanMappings.java
+++ b/modules/beanmapper/src/main/java/com/nortal/petit/beanmapper/ext/ExtendedBeanMappings.java
@@ -1,0 +1,51 @@
+/**
+ *   Copyright 2014 Nortal AS
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.nortal.petit.beanmapper.ext;
+
+import com.nortal.petit.beanmapper.BeanMapping;
+
+/**
+ * @author Aleksei Lissitsin
+ */
+public class ExtendedBeanMappings {
+    private static ExtendedBeanMappingFactory factory = new ExtendedBeanMappingFactoryImpl();
+
+    public static void setFactory(ExtendedBeanMappingFactory factory) {
+        ExtendedBeanMappings.factory = factory;
+    }
+
+    /**
+     * Gets an extended beanMapping.
+     * 
+     * @param extendedProps
+     *            are in the form name1, column1, name2, column2, ... and
+     *            expected to contain an even number of elements.
+     */
+    public static <B> BeanMapping<B> get(Class<B> beanClass,
+            String... extendedProps) {
+        if (extendedProps.length % 2 != 0) {
+            throw new IllegalArgumentException(
+                    "ExtendedBeanMappings#get: extendedProps are expected to have an even number of elements!");
+        }
+        BeanMapping<B> mapping = ExtendedBeanMappingCache.getInstance().get(
+                beanClass, extendedProps);
+        if (mapping == null) {
+            mapping = factory.create(beanClass, extendedProps);
+            ExtendedBeanMappingCache.getInstance().put(beanClass, mapping);
+        }
+        return mapping;
+    }
+}

--- a/modules/orm/src/main/java/com/nortal/petit/orm/BeanMappers.java
+++ b/modules/orm/src/main/java/com/nortal/petit/orm/BeanMappers.java
@@ -17,6 +17,7 @@ package com.nortal.petit.orm;
 
 import com.nortal.petit.beanmapper.BeanMapper;
 import com.nortal.petit.beanmapper.BeanMappings;
+import com.nortal.petit.beanmapper.ext.ExtendedBeanMappings;
 
 /**
  * @author Aleksei Lissitsin
@@ -24,6 +25,20 @@ import com.nortal.petit.beanmapper.BeanMappings;
  */
 public abstract class BeanMappers {
     public static <B> BeanMapper<B> get(Class<B> beanClass) {
-        return new BeanMapper<B>(BeanMappings.get(beanClass), new DefaultResultSetReader());
+        return new BeanMapper<B>(BeanMappings.get(beanClass),
+                new DefaultResultSetReader());
+    }
+
+    /**
+     * Gets a beanMapper with an underlying extended beanMapping.
+     * 
+     * @param extProps
+     *            are in the form name1, column1, name2, column2, ... and
+     *            expected to contain an even number of elements.
+     */
+    public static <B> BeanMapper<B> extended(Class<B> beanClass,
+            String... extProps) {
+        return new BeanMapper<B>(ExtendedBeanMappings.get(beanClass, extProps),
+                new DefaultResultSetReader());
     }
 }

--- a/modules/orm/src/main/java/com/nortal/petit/orm/statement/LoadStatement.java
+++ b/modules/orm/src/main/java/com/nortal/petit/orm/statement/LoadStatement.java
@@ -50,7 +50,8 @@ public class LoadStatement<B> extends SimpleStatement<B> implements SelectClause
     @Override
     public LoadStatement<B> select(String... properties) {
         getStatementBuilder().select(properties);
-        updateMapper(new BeanMapper<B>(new RestrictedBeanMapping<B>(getMapping(), properties), DefaultResultSetReader.instance()));
+        updateMapper(new BeanMapper<B>(new RestrictedBeanMapping<B>(getMapping(), properties),
+                DefaultResultSetReader.instance()));
         return this;
     }
 
@@ -78,7 +79,7 @@ public class LoadStatement<B> extends SimpleStatement<B> implements SelectClause
 
     @Override
     protected void prepare() {
-        getStatementBuilder().setPropertyNameMapper(getMapping().getPropertyNameMapper(true));
+        getStatementBuilder().setPropertyNameMapper(StatementUtil.getPropertyNameMapper(getMapping(), true));
         // If no specific select is set select all props
         if (!getStatementBuilder().isSetSelect()) {
             getStatementBuilder().select(StatementUtil.toStringArray(getMapping().props().keySet()));
@@ -87,8 +88,8 @@ public class LoadStatement<B> extends SimpleStatement<B> implements SelectClause
     }
 
     /**
-     * Return the first item from matching list. 
-     * Returns <code>null</code> if no result. 
+     * Return the first item from matching list.
+     * Returns <code>null</code> if no result.
      * 
      * @return
      */
@@ -103,8 +104,10 @@ public class LoadStatement<B> extends SimpleStatement<B> implements SelectClause
     }
 
     /**
-     * Query for single object. Will return <code>null</code> if not element found.
-     * Throws {@link IncorrectResultSizeDataAccessException} if more than one element returned.
+     * Query for single object. Will return <code>null</code> if not element
+     * found.
+     * Throws {@link IncorrectResultSizeDataAccessException} if more than one
+     * element returned.
      * 
      * @return
      */
@@ -116,16 +119,17 @@ public class LoadStatement<B> extends SimpleStatement<B> implements SelectClause
             return null;
         }
     }
-    
+
     /**
      * Query for single object.
-     * Throws {@link IncorrectResultSizeDataAccessException} if not exactly one element returned.
+     * Throws {@link IncorrectResultSizeDataAccessException} if not exactly one
+     * element returned.
      * 
      * @return
      */
     public B require() {
         prepare();
-        return getJdbcTemplate().queryForObject(getSql(),  getMapper(), getParams(null));
+        return getJdbcTemplate().queryForObject(getSql(), getMapper(), getParams(null));
     }
 
     public List<B> range(int start, int limit) {

--- a/modules/orm/src/main/java/com/nortal/petit/orm/statement/StatementUtil.java
+++ b/modules/orm/src/main/java/com/nortal/petit/orm/statement/StatementUtil.java
@@ -17,6 +17,13 @@ package com.nortal.petit.orm.statement;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.util.Assert;
+
+import com.google.common.base.Function;
+import com.nortal.petit.beanmapper.BeanMapping;
+import com.nortal.petit.beanmapper.Property;
 
 /**
  * @author Aleksei Lissitsin
@@ -33,4 +40,24 @@ class StatementUtil {
         return array;
     }
 
+    static <B> Function<String, String> getPropertyNameMapper(
+            final BeanMapping<B> mapping, final boolean includeReadOnly) {
+        return new Function<String, String>() {
+            public String apply(String name) {
+                return getColumn(mapping.props(), name, includeReadOnly);
+            }
+        };
+    }
+
+    private static <B> String getColumn(Map<String, Property<B, Object>> props,
+            String name, boolean includeReadOnly) {
+        Property<B, Object> p = props.get(name);
+        if (p == null) {
+            Assert.notNull(p, "No property " + name + " found!");
+        }
+        if (includeReadOnly || !p.readOnly()) {
+            return p.column();
+        }
+        return null;
+    }
 }

--- a/modules/orm/src/test/java/com/nortal/petit/orm/mapper/BeanMapperTest.java
+++ b/modules/orm/src/test/java/com/nortal/petit/orm/mapper/BeanMapperTest.java
@@ -30,6 +30,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import com.mockrunner.jdbc.PreparedStatementResultSetHandler;
 import com.mockrunner.mock.jdbc.MockConnection;
 import com.mockrunner.mock.jdbc.MockResultSet;
+import com.nortal.petit.orm.BeanMappers;
 import com.nortal.petit.orm.MockrunnerBaseTest;
 import com.nortal.petit.orm.mapper.fixture.MapperTestBean;
 import com.nortal.petit.orm.statement.LoadStatement;
@@ -57,7 +58,7 @@ public class BeanMapperTest extends MockrunnerBaseTest {
     @Test
     public void test__beanMapperExtendedMapper() {
         LoadStatement<MapperTestBean> loadStm = ss.loadStm(MapperTestBean.class).where(eq("id", 1L));
-        loadStm.getMapper().add("optional", "optional");
+        loadStm.setExtendedProperties("optional", "optional");
         MapperTestBean single = loadStm.single();
 
         verifyNumberPreparedStatements(1);
@@ -73,7 +74,7 @@ public class BeanMapperTest extends MockrunnerBaseTest {
         assertThat(loaded.getOptional(), is(nullValue()));
 
         LoadStatement<MapperTestBean> loadStm = ss.loadStm(MapperTestBean.class).where(eq("id", 1L));
-        loadStm.getMapper().add("optional", "optional");
+        loadStm.setExtendedProperties("optional", "optional");
         MapperTestBean loaded2 = loadStm.single();
         assertThat(loaded2.getOptional(), equalTo("Optional result"));
 
@@ -88,7 +89,7 @@ public class BeanMapperTest extends MockrunnerBaseTest {
 //        assertThat(mtb.getOptional(), is(nullValue()));
 //        assertThat(mtb.getDescription(), is(notNullValue()));
         
-        loadStm.getMapper().add("optional", "optional");
+        loadStm.setExtendedProperties("optional", "optional");
         MapperTestBean mtb2 = loadStm.single();
         assertThat(mtb2.getOptional(), is(notNullValue()));
         assertThat(mtb2.getDescription(), is(notNullValue()));


### PR DESCRIPTION
I thought about this for awhile. Consider the following approach.

This caches extended beanMappings. The interface for `BeanMapper` users is `BeanMappers.extended(clazz, "propname1", "column1", "propname2", "column2", ...)` or `ExtendedBeanMappings.get(<the same>)`.

For statements, the simplest way was to add `setExtendedProperties` method. 

Because we do not want to advertise the use of this functionality (the better way would be to have a specialized model class for every usecase), this is perhaps sufficient. 

However, it might be useful to feed beanMapping objects to statements in addition to bean classes. This should offer a more fine-grained way to use statements, because beanMappings do not have to be reflection-based - and may be constructed by hand when necessary (e.g., via Java8 lambdas).